### PR TITLE
Startup studio edition

### DIFF
--- a/build_buildboard.py
+++ b/build_buildboard.py
@@ -116,9 +116,8 @@ def save_team_photos(team_constants):
 
 def get_teams(teams_file):
     with open(teams_file) as tf:
-        team_metadata = [team.strip() for team in tf.readlines()]
-    team_constants = [team.split("\t")[3] for team in team_metadata]
-    return (team_constants, team_metadata)
+        teams = [team.strip() for team in tf.readlines()]
+        return teams
 
 def get_crit_groups_ordered_by_room(teams_metadata):
     crit_rooms = {'A': {}, 'B' : {}}
@@ -213,6 +212,7 @@ def output_crit_groups_xlsx(group, rooms, teams):
                 row += 1
     workbook.close()
 
+# TODO: deprecate this in favor of a futuristic model
 def build_crit_pages(teams, teams_metadata):
     def create_crit_group_pages(group, data):
         crit_file = os.path.join(constants.PWD, constants.OUTPUT_DIR_NAME, constants.CRIT_FILE_NAME % group)
@@ -241,15 +241,14 @@ def create_all_pages(local_data):
     setup_output_directories(constants.PWD)
 
     teams_file = os.path.join(constants.PWD, constants.TEAMS_FILE_NAME)
-    (team_constants, teams_metadata) = get_teams(teams_file)
+    team_names = get_teams(teams_file)
 
     if not local_data:
-        save_team_files(team_constants)
-        save_team_photos(team_constants)
+        save_team_files(team_names)
+        save_team_photos(team_names)
 
-    teams = load_teams_data(team_constants)
+    teams = load_teams_data(team_names)
     build_new_site_design(teams)
-    build_crit_pages(teams, teams_metadata)
 
 def write_template_output_to_file(output, dst):
     if output:

--- a/build_buildboard.py
+++ b/build_buildboard.py
@@ -186,15 +186,15 @@ def create_crit_pages(crit_groups, teams):
 
         return (crit_A, crit_B)
 
-def create_directory_page(teams):
+def create_directory_page(teams, semester):
     template = TEMPLATES[DIRECTORY_T]
     if template:
-        return template.render(teams=teams, semester=args.semester)
+        return template.render(teams=teams, semester=semester)
 
-def create_team_page(team):
+def create_team_page(team, semester):
     template = TEMPLATES[TEAM_CARD_T]
     if template:
-        return template.render(team=team, semester=args.semester)
+        return template.render(team=team, semester=semester)
 
 # TODO: deprecate in favor of futuristic version
 def output_crit_groups_xlsx(group, rooms, teams):
@@ -228,19 +228,19 @@ def build_crit_pages(teams, teams_metadata):
         create_crit_group_pages('A', crit_groups_data[0])
         create_crit_group_pages('B', crit_groups_data[1])
 
-def build_new_site_design(teams):
-    directory = create_directory_page(teams)
+def build_new_site_design(teams, semester):
+    directory = create_directory_page(teams, semester)
     directory_file = os.path.join(constants.PWD, constants.OUTPUT_DIR_NAME, constants.DIRECTORY_PAGE_NAME)
     write_template_output_to_file(directory, directory_file)
 
     for team in teams:
         team_content = teams[team]
-        team_page = create_team_page(team_content)
+        team_page = create_team_page(team_content, semester)
         team_page_file = os.path.join(constants.PWD, constants.OUTPUT_DIR_NAME, constants.TEAM_PAGES_DIR_NAME,
                                         "%s.html" % team)
         write_template_output_to_file(team_page, team_page_file)
 
-def create_all_pages(local_data):
+def create_all_pages(local_data, semester):
     setup_output_directories(constants.PWD)
 
     teams_file = os.path.join(constants.PWD, constants.TEAMS_FILE_NAME)
@@ -251,7 +251,7 @@ def create_all_pages(local_data):
         save_team_photos(team_names)
 
     teams = load_teams_data(team_names)
-    build_new_site_design(teams)
+    build_new_site_design(teams, semester)
 
 def write_template_output_to_file(output, dst):
     if output:
@@ -294,4 +294,4 @@ if __name__ == '__main__':
     args = parser.parse_args()
     config_logging(args)
     verify_templates()
-    create_all_pages(args.local_data)
+    create_all_pages(args.local_data, args.semester)

--- a/build_buildboard.py
+++ b/build_buildboard.py
@@ -19,6 +19,7 @@ parser = argparse.ArgumentParser(description="Top-level flags.")
 parser.add_argument('--local-data', action='store_true')
 parser.add_argument('--log-to-stdout', action='store_true')
 parser.add_argument('--log-file', action='store')
+parser.add_argument('--semester', action='store', choices=['spring', 'fall'], required=True)
 
 g = github.Github(constants.GITHUB_ACCESS_TOKEN)
 env = Environment(loader=PackageLoader('buildboard', 'templates'),
@@ -119,6 +120,7 @@ def get_teams(teams_file):
         teams = [team.strip() for team in tf.readlines()]
         return teams
 
+# TODO: deprecate in favor of the futuristic version
 def get_crit_groups_ordered_by_room(teams_metadata):
     crit_rooms = {'A': {}, 'B' : {}}
     for team_line in teams_metadata:

--- a/build_buildboard.py
+++ b/build_buildboard.py
@@ -142,6 +142,11 @@ def load_teams_data(team_constants):
         team_doc = get_yaml_doc(team_name)
         if team_doc:
             team_doc['repo'] = team_name
+
+            # check length of product narrative
+            product_narrative = team_doc['product_narrative']
+            if len(product_narrative) > 140:
+                logging.warning('product narrative for team %s is too long: %d characters' % (team_name, len(product_narrative)))
         else:
             logging.error("missing yaml: %s" % team_name)
         team_data[team_name] = team_doc

--- a/build_buildboard.py
+++ b/build_buildboard.py
@@ -196,6 +196,7 @@ def create_team_page(team):
     if template:
         return template.render(team=team, semester=args.semester)
 
+# TODO: deprecate in favor of futuristic version
 def output_crit_groups_xlsx(group, rooms, teams):
     workbook = xlsxwriter.Workbook(os.path.join(constants.PWD, constants.OUTPUT_DIR_NAME, constants.XLSX_FILE_NAME % group))
     worksheet = workbook.add_worksheet()

--- a/build_buildboard.py
+++ b/build_buildboard.py
@@ -100,7 +100,7 @@ def save_team_photos(team_constants):
                             handle_photos.get_photo_path_for_web(handle_photos.save_photo_path(constants.INDIVIDUAL_PHOTOS_DIR_NAME,
                                                                 sanified_email, individual_photo))
 
-                    except (KeyError, TypeError, IOError), e:
+                    except (KeyError, TypeError, IOError, AttributeError), e:
                         # overwrite file with default member image for failed picture
                         teammate['picture'] = 'static/member3x.png'
                         logging.error('repo %s missing individual photo for member %s: %s' % (team_name, teammate['email'], str(e)))

--- a/build_buildboard.py
+++ b/build_buildboard.py
@@ -189,12 +189,12 @@ def create_crit_pages(crit_groups, teams):
 def create_directory_page(teams):
     template = TEMPLATES[DIRECTORY_T]
     if template:
-        return template.render(teams=teams)
+        return template.render(teams=teams, semester=args.semester)
 
 def create_team_page(team):
     template = TEMPLATES[TEAM_CARD_T]
     if template:
-        return template.render(team=team)
+        return template.render(team=team, semester=args.semester)
 
 def output_crit_groups_xlsx(group, rooms, teams):
     workbook = xlsxwriter.Workbook(os.path.join(constants.PWD, constants.OUTPUT_DIR_NAME, constants.XLSX_FILE_NAME % group))

--- a/constants.py
+++ b/constants.py
@@ -21,8 +21,9 @@ YAML_DIR_NAME = "yaml"
 TEAM_PHOTOS_DIR_NAME = "team_photos"
 COMPANY_LOGOS_DIR_NAME = "logos"
 INDIVIDUAL_PHOTOS_DIR_NAME = "individual_pictures"
-CRIT_FILE_NAME = "crit-%s.html"
-XLSX_FILE_NAME = "narratives-%s.xlsx"
+# TODO: deprecate in favor of futuristic version
+# CRIT_FILE_NAME = "crit-%s.html"
+# XLSX_FILE_NAME = "narratives-%s.xlsx"
 
 # new site design names
 DIRECTORY_PAGE_NAME = "index.html"

--- a/create_teams.py
+++ b/create_teams.py
@@ -18,7 +18,7 @@ GITHUB_ACCESS_TOKEN = os.environ.get('GITHUB_ACCESS_TOKEN', None)
 STUDENTS_TO_TEAMS = "teams2students.txt"
 
 
-TEAMS_FILE = "create-team-repos"
+TEAMS_FILE = "teams-sp18.txt"
 ORG_NAME = "ct-product-challenge-2017"
 STUDIO_TEAM_ID = 2477099
 
@@ -82,6 +82,7 @@ def populate_all_teams(g):
 
 if __name__ == '__main__':
     g = github.Github(GITHUB_ACCESS_TOKEN)
+    # create_all_teams(g)
     populate_all_teams(g)
     # ts = create_teams_map()
     # for t in ts.keys():

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ idna==2.6
 itsdangerous==0.24
 Jinja2==2.9.6
 MarkupSafe==1.0
+Pillow==5.0.0
 PyGithub==1.35
 PyJWT==1.5.3
 python-dotenv==0.6.5
@@ -13,4 +14,4 @@ PyYAML==3.12
 requests==2.18.4
 urllib3==1.22
 Werkzeug==0.12.2
-XlsxWriter==1.0.0
+XlsxWriter==1.0.2

--- a/teams
+++ b/teams
@@ -1,52 +1,57 @@
-S4	Bloomberg LP	#PC011	bloomberg-skills	A	131
-S3	Gates Foundation	#PC009	bmgf-money	A	131
-S1	WCMC	#PC099	wcmc-handwritten-charts	A	131
-S4	Amazon	#PC004	amazon-photo-video-sharing	A	141
-S2	AutoDesk	#PC006	autodesk-urban-mobility	A	141
-S2	eBay	#PC028	ebay-complementary-fashion	A	141
-S1	MSK	#PC053	msk-vr	A	141
-S3	Bloomberg LP	#PC013	bloomberg-cryptocurrencies	A	151
-S2	VaynerMedia	#PC090	vaynermedia-fake-news	A	151
-S3	Verizon	#PC092	verizon-customer-experience	A	151
-S3	Betterment	#PC008	betterment-blockchain	A	3rd Bowtie East
-S2	Toyota	#PC042	toyota-trust-selfdriving-cars	A	3rd Bowtie East
-S4	XO Group	#PC101	xogroup-wedding	A	3rd Bowtie East
-S2	Amazon	#PC005	amazon-commuters	A	3rd Bowtie West
-S4	My Little Health Bot	#PC057	littlehealthboth-robot-retailer	A	3rd Bowtie West
-S3	Mastercard	#PC050	mastercard-transaction-data	A	3rd Bowtie West
-S3	Blue Ridge Labs	#PC014	blueridgelabs-immigrants	A	L23
-S4	Data & Society	#PC024	datasociety-tolerance	A	L23
-S4	NYTimes	#PC059	nytimes-bundles	A	L23
-S3	Roku	#PC073	roku-tv-advertising	A	L23
-S4	Dow Jones	#PC100	dowjones-ai-newsroom	A	Master Loft
-S1	IBM	#PC039	ibm-cancer	A	Master Loft
-S2	Uber	#PC088	uber-communities	A	Master Loft
-S3	Bloomberg LP	#PC012	bloomberg-college	A	Master Loft's Prow
-S4	CampusWire	#PC017	campuswire-student-qa	A	Master Loft's Prow
-S1	Lilly	#PC048	lilly-alzheimer	A	Master Loft's Prow
-S3	Capital One Labs	#PC019	capitalonelabs-blockchain	B	131
-S1	Lilly	#PC049	lilly-objective-data	B	131
-S1	Groceryships	#PC036	groceryships-healthy-choices	B	131
-S2	Grammarly	#PC035	grammarly	B	141
-S3	Domino Data Labs	#PC027	domino-marketplace	B	141
-S1	Mitre	#PC055	mitre-informed-decision	B	141
-S1	Oscar	#PC063	oscar-patient-relationships	B	141
-S4	frog	#PC033	frog-ar-vr	B	151
-S2	Uniqlo	#PC043	inamoto-inventory	B	151
-S4	SAP	#PC076	sap-ar-vr	B	151
-S2	ConEd	#PC023	coned-ev-charging	B	3rd Bowtie East
-S1	Kaltura	#PC046	kaltura-inspection	B	3rd Bowtie East
-S1	WATTx	#PC094	wattx-data-sharing	B	3rd Bowtie East
-S4	Bloomberg LP	#PC010	bloomberg-volunteering	B	3rd Bowtie West
-S2	Qualcomm	#PC071	qualcomm-credibility	B	3rd Bowtie West
-S3	Verizon	#PC091	verizon-civic	B	3rd Bowtie West
-S1	HALE Health	#PC037	hale-health-chronic-diseases	B	L23
-S1	Nielsen	#PC060	nielsen-pos	B	L23
-S2	Two Sigma	#PC087	twosigma-airports	B	L23
-S4	BMW	#PC016	bmw-personalization	B	Master Loft
-S3	Jet Blue	#PC045	jetblue-loyalty-program	B	Master Loft
-S2	PureHouse	#PC069	purehouse-coliving	B	Master Loft
-S1	Samsung	#PC075	samsung-smart-home	B	Master Loft
-S3	Citi	#PC021	citi-transportation	B	Master Loft's Prow
-S2	JCrew	#PC044	jcrew-brick-mortar	B	Master Loft's Prow
-S4	Two Sigma	#PC086	twosigma-game-halite	B	Master Loft's Prow
+CTSS18-1
+CTSS18-2
+CTSS18-3
+CTSS18-4
+CTSS18-5
+CTSS18-6
+CTSS18-7
+CTSS18-8
+CTSS18-9
+CTSS18-10
+CTSS18-11
+CTSS18-12
+CTSS18-13
+CTSS18-14
+CTSS18-15
+CTSS18-16
+CTSS18-17
+CTSS18-18
+CTSS18-19
+CTSS18-20
+CTSS18-21
+CTSS18-22
+CTSS18-23
+CTSS18-24
+CTSS18-25
+CTSS18-26
+CTSS18-27
+CTSS18-28
+CTSS18-29
+CTSS18-30
+CTSS18-32
+CTSS18-33
+CTSS18-34
+CTSS18-35
+CTSS18-36
+CTSS18-37
+CTSS18-38
+CTSS18-39
+CTSS18-40
+CTSS18-41
+CTSS18-42
+CTSS18-43
+CTSS18-44
+CTSS18-45
+CTSS18-46
+CTSS18-47
+CTSS18-48
+CTSS18-49
+CTSS18-50
+CTSS18-51
+CTSS18-31
+CTSS18-52
+CTSS18-53
+CTSS18-54
+CTSS18-55
+CTSS18-56
+CTSS18-57

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,8 +6,13 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-    <title>Product Studio 2017 BuildBoard</title>
+    {% if semester == 'fall' %}
+      <title>Product Studio 2017 BuildBoard</title>
+    {% endif %}
 
+    {% if semester == 'spring' %}
+      <title>Startup Studio 2018 BuildBoard</title>
+    {% endif %}
     <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css">
 
     {% endblock %}

--- a/templates/directory.html
+++ b/templates/directory.html
@@ -15,7 +15,7 @@
   </div> <!-- page-header -->
   {% for team_name in teams %}
     {% set team = teams[team_name] %}
-      {% if team is defined %}
+      {% if team is defined and team is not none %}
         <div class="big-row-outer">
           <div class="big-row">
             {% if semester == 'fall' %} <!-- FALL / PRODUCT STUDIO-->

--- a/templates/directory.html
+++ b/templates/directory.html
@@ -18,13 +18,24 @@
       {% if team is defined %}
         <div class="big-row-outer">
           <div class="big-row">
-            {% with prefix="" %}
-              {% include "roster.html" %}
-            {% endwith %}
-            {% include "team_info.html" %}
-            {% if team['company'] is defined %}
-              <div class="team-logo cover" style="background-image:url({{ team['company']['logo'] }})"> </div> <!-- team-logo -->
-            {% endif %}
+            {% if semester == 'fall' %} <!-- FALL / PRODUCT STUDIO-->
+              {% with prefix="" %}
+                {% include "roster.html" %}
+              {% endwith %}
+              {% include "team_info.html" %}
+              {% if team['company'] is defined %}
+                <div class="team-logo cover" style="background-image:url({{ team['company']['logo'] }})"> </div> <!-- team-logo -->
+              {% endif %}
+            {% endif %} <!-- end FALL / PRODUCT STUDIO-->
+            {% if semester == 'spring' %} <!-- SPRING / STARTUP STUDIO-->
+              {% if team['company'] is defined %}
+                <div class="team-logo cover" style="background-image:url({{ team['company']['logo'] }})"> </div> <!-- team-logo -->
+              {% endif %}
+              {% include "team_info.html" %}
+              {% with prefix="" %}
+                {% include "roster.html" %}
+              {% endwith %}
+            {% endif %} <!-- end SPRING / STARTUP STUDIO-->
           </div> <!-- big-row -->
         </div> <!-- big-row-outer -->
      {% endif %}

--- a/templates/directory.html
+++ b/templates/directory.html
@@ -7,7 +7,12 @@
 
 {% block content %}
   <div class="page-header">
-    <div class="page-header-title"> Product Studio Teams </div>
+    {% if semester == 'fall' %}
+      <div class="page-header-title"> Product Studio Teams </div>
+    {% endif %}
+    {% if semester == 'spring' %}
+      <div class="page-header-title"> Startup Studio 2018 </div>
+    {% endif %}
     <!-- <div class="page-header-footer"> Topics: -->
         <!-- <span class="tag-placeholder">VR</span> -->
         <!-- <span class="tag-placeholder">Health Tech</span> -->

--- a/templates/team_card.html
+++ b/templates/team_card.html
@@ -53,7 +53,12 @@
             <div class="team-info-header">
               {% if team['company'] is defined %}
                 <div class="team-info-header-company">{{ team['company']['name']}} asked</div>
-                <div class="h-m-w"> {{ team['how_might_we']}}</div>
+                {% if semester == 'fall' %}
+                  <div class="h-m-w"> {{ team['how_might_we']}}</div>
+                {% endif %}
+                {% if semester == 'spring' %}
+                  <div class="h-m-w"> {{ team['product_hmw']}}</div>
+                {% endif %}
               {% endif %}
             {% include "team_info_card.html" %}
           </div> <!-- righthand-column -->

--- a/update_buildboard.py
+++ b/update_buildboard.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
 	build_buildboard.config_logging(args)
 	build_buildboard.verify_templates()
 	build_buildboard.create_dir(args.dir)
-	build_buildboard.create_all_pages(args.local_data)
+	build_buildboard.create_all_pages(args.local_data, args.semester)
 
     # TODO: deprecate in favor of futuristic version
 	# copy_to_site_directory(constants.CRIT_FILE_NAME % 'A')

--- a/update_buildboard.py
+++ b/update_buildboard.py
@@ -37,10 +37,11 @@ if __name__ == '__main__':
 	build_buildboard.create_dir(args.dir)
 	build_buildboard.create_all_pages(args.local_data)
 
-	copy_to_site_directory(constants.CRIT_FILE_NAME % 'A')
-	copy_to_site_directory(constants.CRIT_FILE_NAME % 'B')
-	copy_to_site_directory(constants.XLSX_FILE_NAME % 'A')
-	copy_to_site_directory(constants.XLSX_FILE_NAME % 'B')
+    # TODO: deprecate in favor of futuristic version
+	# copy_to_site_directory(constants.CRIT_FILE_NAME % 'A')
+	# copy_to_site_directory(constants.CRIT_FILE_NAME % 'B')
+	# copy_to_site_directory(constants.XLSX_FILE_NAME % 'A')
+	# copy_to_site_directory(constants.XLSX_FILE_NAME % 'B')
 
 	# new site directory
 	copy_to_site_directory(constants.DIRECTORY_PAGE_NAME)


### PR DESCRIPTION
Updates to allow a startup studio version of the site. Choose which site to run through required flag --semester, with options spring vs. fall.

* add flags
* change position of logo vs. roster depending on semester
* change various text fields (page title, header, etc) based on semester
* render team card differently fall vs spring
* remove updates to deprecated pages (critA/critB, xlsx)
* small bug fixes